### PR TITLE
Remove 'express' dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "aerospike": "^2.0",
-    "express": "^3.0",
     "express-session": "^1.0",
     "debug": "^2.2.0"
   },


### PR DESCRIPTION
It seems like Express isn't used anywhere and it's a huge dependency taking a lot of time to install.
