### PR TITLE
Update to Aerospike Node.js Client v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+.DS_Store
+.nyc_output
+coverage
 node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: node_js
 node_js:
 - 'node'
-- '5'
+- '6'
 - '4'
-- '0.12'
-- 'iojs'
 env:
-- CXX=g++-4.8
+  global:
+    - CXX=g++-4.8
+    - AEROSPIKE_HOSTS=127.0.0.1:3000,127.0.0.1:3100
 sudo: false
 os:
 - linux
@@ -18,23 +18,11 @@ addons:
     packages:
       - g++-4.8
       - autoconf
-      - libssl-dev
+before_script:
+- .travis/start_cluster.sh 2
 install:
-- wget -O aerospike-server.tgz http://aerospike.com/download/server/latest/artifact/tgz
-- tar xvzf aerospike-server.tgz
-- cp -f .travis/aerospike.conf ./aerospike-server/share/etc
-- cd aerospike-server
-- sed -i -e 's/\${me}/"root"/' share/libexec/aerospike-start
-- sed -i -e 's/set_shmmax$/#set_shmmax/' share/libexec/aerospike-start
-- sed -i -e 's/set_shmall$/#set_shmall/' share/libexec/aerospike-start
-- mkdir instance1
-- ./bin/aerospike init --home instance1 --instance 1 --service-port 3000
-- cd instance1
-- ./bin/aerospike start
-- ../../scripts/wait-for-node.sh var/log/aerospike.log
-- cd ../..
-script:
 - npm install
+script:
 - npm test
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,9 @@ before_script:
 install:
 - npm install
 script:
-- npm test
+- npm run coverage
+after_script:
+- npm run codecov
 notifications:
   email:
   - qe-notices@aerospike.com

--- a/.travis/start_cluster.sh
+++ b/.travis/start_cluster.sh
@@ -47,6 +47,7 @@ function start_server {
   instance=$1
   dir="instance${instance}"
   port=$((2900 + 100 * $instance))
+  echo "## Starting Aerospike instance ${instance}/${nodes} on port ${port}"
   mkdir ${dir}
   ./bin/aerospike init --home ${dir} --instance ${instance} --service-port ${port}
   cd ${dir}
@@ -71,7 +72,6 @@ echo "## Fetching Aerospike server distribution"
 install_server
 for ((node = 1; node <= nodes; node++))
 do
-  echo "## Starting Aerospike server instance ${node}/${nodes}"
   start_server $node
 done
 cd ${pwd}

--- a/.travis/start_cluster.sh
+++ b/.travis/start_cluster.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+################################################################################
+# Copyright 2013-2017 Aerospike, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+nodes=${1:-1}
+home=$(pwd)
+
+function wait_for_node {
+  log=$1
+  if [ ! -f $log ]
+  then
+    echo "A log file does not exist at $(pwd)/${log}"
+    exit 1
+  fi
+
+  i=0
+  while [ $i -le 12 ]
+  do
+    sleep 1
+    grep -i "there will be cake" ${log}
+    if [ $? == 0 ]; then
+      return 0
+    else
+      i=$(($i + 1))
+      echo -n "."
+    fi
+  done
+  echo "The cake is a lie!"
+  tail -n 1000 ${log}
+  exit 2
+}
+
+function start_server {
+  instance=$1
+  dir="instance${instance}"
+  port=$((2900 + 100 * $instance))
+  mkdir ${dir}
+  ./bin/aerospike init --home ${dir} --instance ${instance} --service-port ${port}
+  cd ${dir}
+  ./bin/aerospike start
+  wait_for_node "var/log/aerospike.log"
+  cd ..
+}
+
+function install_server {
+  wget -nv -O aerospike-server.tgz http://aerospike.com/download/server/latest/artifact/tgz
+  tar xzf aerospike-server.tgz
+  cp -f .travis/aerospike.conf ./aerospike-server/share/etc
+  cd aerospike-server
+  sed -i -e 's/\${me}/"root"/' share/libexec/aerospike-start
+  sed -i -e 's/set_shmmax$/#set_shmmax/' share/libexec/aerospike-start
+  sed -i -e 's/set_shmall$/#set_shmall/' share/libexec/aerospike-start
+  sed -i -e 's/set_socket_buffer_limits$/#set_socket_buffer_limits/' share/libexec/aerospike-start
+  sed -i -e 's/ulimit/#ulimit/' share/libexec/aerospike-start
+}
+
+echo "## Fetching Aerospike server distribution"
+install_server
+for ((node = 1; node <= nodes; node++))
+do
+  echo "## Starting Aerospike server instance ${node}/${nodes}"
+  start_server $node
+done
+cd ${pwd}

--- a/lib/aerospike_store.js
+++ b/lib/aerospike_store.js
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright 2016 Aerospike, Inc.
+// Copyright 2016-2017 Aerospike, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
@@ -14,8 +14,9 @@
 // limitations under the License.
 // *****************************************************************************
 
+'use strict'
+
 const Aerospike = require('aerospike')
-const Key = Aerospike.Key
 
 const debug = require('debug')('session:aerospike')
 const util = require('util')
@@ -30,7 +31,6 @@ module.exports = function (session) {
 
     options = options || {}
     Store.call(this, options)
-    var self = this
 
     this.as_namespace = options.namespace || 'test'
     this.as_set = options.set || 'express-session'
@@ -41,12 +41,12 @@ module.exports = function (session) {
       this.client = options.client
     } else {
       this.client = Aerospike.client(options)
-      this.client.connect(function (err) {
-        if (err) {
-          debug('ERROR - %s', err.message)
-          self.emit('disconnect')
+      this.client.connect(error => {
+        if (error) {
+          debug('ERROR - %s', error.message)
+          this.emit('disconnect')
         } else {
-          self.emit('connect')
+          this.emit('connect')
         }
       })
     }
@@ -55,7 +55,7 @@ module.exports = function (session) {
   util.inherits(AerospikeStore, Store)
 
   AerospikeStore.prototype._key = function (sid) {
-    return new Key(this.as_namespace, this.as_set, sid)
+    return new Aerospike.Key(this.as_namespace, this.as_set, sid)
   }
 
   // Determines the time-to-live (TTL) to use when writing a record for
@@ -65,11 +65,11 @@ module.exports = function (session) {
   // negative, ttl will not be used. However, note that the Aerospike server
   // might still have a default ttl at the namespace level.
   AerospikeStore.prototype._ttl = function (session) {
-    var ttl = null
+    let ttl = null
     if (typeof this.ttl === 'number') {
       ttl = this.ttl
     } else {
-      var maxAge = session.cookie && session.cookie.maxAge
+      const maxAge = session.cookie && session.cookie.maxAge
       if (typeof maxAge === 'number') {
         ttl = Math.floor(maxAge / 1000)
       }
@@ -82,10 +82,9 @@ module.exports = function (session) {
 
   // Get a session from the store given a session ID (sid).
   AerospikeStore.prototype.get = function (sid, callback) {
-    var self = this
-    var key = this._key(sid)
+    const key = this._key(sid)
     debug('GET "%s"', sid)
-    this.client.get(key, function (err, record) {
+    this.client.get(key, (err, record) => {
       if (err) {
         switch (err.code) {
           case Aerospike.status.AEROSPIKE_ERR_RECORD_NOT_FOUND:
@@ -95,15 +94,18 @@ module.exports = function (session) {
         }
       }
 
-      var session = record.session
-      if (session) {
-        try {
-          session = self.serializer.parse(session)
-        } catch (err) {
-          return callback(err)
-        }
+      const bins = record.bins
+      const sessionBin = bins.session
+      if (!sessionBin) {
+        return callback()
       }
-      return callback(null, session)
+
+      try {
+        const session = this.serializer.parse(sessionBin)
+        return callback(null, session)
+      } catch (err) {
+        return callback(err)
+      }
     })
   }
 
@@ -112,7 +114,7 @@ module.exports = function (session) {
     if (typeof callback !== 'function') {
       callback = function (err) { if (err) debug('ERR', err.message) }
     }
-    var key = this._key(sid)
+    const key = this._key(sid)
     debug('REMOVE "%s"', sid)
     this.client.remove(key, function (err) {
       callback(err)
@@ -121,32 +123,33 @@ module.exports = function (session) {
 
   // Upsert a session into the store given a session ID (sid) and session (session) object.
   AerospikeStore.prototype.set = function (sid, session, callback) {
-    var key = this._key(sid)
+    const key = this._key(sid)
+    const bins = {}
     try {
-      var record = { session: this.serializer.stringify(session) }
+      bins.session = this.serializer.stringify(session)
     } catch (err) {
       process.nextTick(function () { callback(err) })
       return
     }
-    var meta = {}
-    var ttl = this._ttl(session)
+    const meta = {}
+    const ttl = this._ttl(session)
     if (ttl) {
       meta.ttl = ttl
       debug('PUT "%s", ttl: %s', sid, ttl)
     } else {
       debug('PUT "%s"', sid)
     }
-    this.client.put(key, record, meta, function (err) {
+    this.client.put(key, bins, meta, function (err) {
       callback(err)
     })
   }
 
   // "Touch" a given session given a session ID (sid) and session (session) object.
   AerospikeStore.prototype.touch = function (sid, session, callback) {
-    var key = this._key(sid)
-    var ttl = this._ttl(session)
+    const key = this._key(sid)
+    const ttl = this._ttl(session)
     if (ttl) {
-      var ops = [ Aerospike.operations.touch(ttl) ]
+      const ops = [ Aerospike.operations.touch(ttl) ]
       debug('TOUCH "%s" %s', sid, ttl)
       this.client.operate(key, ops, function (err) {
         callback(err)

--- a/lib/aerospike_store.js
+++ b/lib/aerospike_store.js
@@ -159,5 +159,10 @@ module.exports = function (session) {
     }
   }
 
+  // Delete all sessions from the store.
+  AerospikeStore.prototype.clear = function (callback) {
+    this.client.truncate(this.as_namespace, this.as_set, callback)
+  }
+
   return AerospikeStore
 }

--- a/package.json
+++ b/package.json
@@ -14,20 +14,24 @@
     "url": "https://github.com/aerospike/aerospike-session-store-expressjs"
   },
   "dependencies": {
-    "aerospike": "^2.0",
-    "express-session": "^1.0",
-    "debug": "^2.2.0"
+    "aerospike": "^3.0.0",
+    "debug": "^2.6.9",
+    "express-session": "^1.15.6"
   },
   "devDependencies": {
     "blue-tape": "^0.2",
-    "bluebird": "^3.0",
-    "standard": "^7.0",
-    "tape": "^4.2.1"
+    "bluebird": "^3.5.1",
+    "codecov": "^2.3.0",
+    "nyc": "^11.2.1",
+    "standard": "^10.0",
+    "tape": "^4.8.0"
   },
   "scripts": {
-    "test": "standard && DEBUG=* tape \"test/*_test.js\"",
+    "test": "DEBUG=session:* tape \"test/*_test.js\"",
+    "posttest": "standard",
     "bench": "node benchmark/aerospikebench",
-    "lint": "standard"
+    "coverage": "nyc npm test; nyc --reporter=lcov report",
+    "codecov": "codecov"
   },
   "bugs": {
     "url": "https://github.com/aerospike/aerospike-session-store-expressjs/issues"

--- a/test/aerospike_store_test.js
+++ b/test/aerospike_store_test.js
@@ -1,8 +1,26 @@
+// *****************************************************************************
+// Copyright 2016-2017 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// *****************************************************************************
+
+'use strict'
+
 const Promise = require('bluebird')
 const test = require('blue-tape')
 const session = require('express-session')
 const AerospikeStore = require('../')(session)
-const Aerospike = Promise.promisifyAll(require('aerospike'))
+const Aerospike = require('aerospike')
 
 function lifecycleTest (store, t) {
   Promise.promisifyAll(store)
@@ -19,7 +37,7 @@ function lifecycleTest (store, t) {
 }
 
 test('defaults', function (t) {
-  var store = new AerospikeStore()
+  const store = new AerospikeStore()
   t.equal(store.as_namespace, 'test', 'sets default namespace to test')
   t.equal(store.as_set, 'express-session', 'sets default set name to express-session')
   t.notOk(store.ttl, 'ttl not set')
@@ -31,20 +49,20 @@ test('defaults', function (t) {
 
 test('basic', function (t) {
   t.throws(AerospikeStore, TypeError, 'constructor not callable as function')
-  var store = new AerospikeStore()
+  const store = new AerospikeStore()
   return lifecycleTest(store, t)
 })
 
 test('existing client', function (t) {
-  return Aerospike.connectAsync()
+  return Aerospike.connect()
     .then(function (client) {
-      var store = new AerospikeStore({ client: client })
+      const store = new AerospikeStore({ client: client })
       return lifecycleTest(store, t)
     })
 })
 
 test('options', function (t) {
-  var store = new AerospikeStore({
+  const store = new AerospikeStore({
     namespace: 'express',
     set: 'session',
     ttl: 3600
@@ -58,7 +76,7 @@ test('options', function (t) {
 })
 
 test('failed connection', function (t) {
-  var store = new AerospikeStore({ hosts: '127.0.0.1:3333', connTimeoutMs: 500 })
+  const store = new AerospikeStore({ hosts: '127.0.0.1:3333', connTimeoutMs: 500 })
   Promise.promisifyAll(store)
 
   return store.setAsync('sid', { cookie: { maxAge: 2000 }, name: 'jan' })
@@ -69,17 +87,17 @@ test('failed connection', function (t) {
 })
 
 test('serializer', function (t) {
-  var serializer = {
-    stringify: function () { return 'XXX' + JSON.stringify.apply(JSON, arguments) },
-    parse: function (x) {
-      t.ok(x.match(/^XXX/))
-      return JSON.parse(x.substring(3))
+  const serializer = {
+    stringify: (value, replacer, space) => 'XXX' + JSON.stringify(value, replacer, space),
+    parse: str => {
+      t.ok(str.match(/^XXX/))
+      return JSON.parse(str.substring(3))
     }
   }
   t.equal(serializer.stringify('UnitTest'), 'XXX"UnitTest"')
   t.equal(serializer.parse(serializer.stringify('UnitTest')), 'UnitTest')
 
-  var store = new AerospikeStore({ serializer: serializer })
+  const store = new AerospikeStore({ serializer: serializer })
   return lifecycleTest(store, t)
 })
 

--- a/test/aerospike_store_test.js
+++ b/test/aerospike_store_test.js
@@ -53,6 +53,17 @@ test('basic', function (t) {
   return lifecycleTest(store, t)
 })
 
+test('clear', function (t) {
+  const store = new AerospikeStore()
+  Promise.promisifyAll(store)
+
+  return store.setAsync('sess1', { name: 'jan' })
+    .then(() => store.clearAsync())
+    .then(() => store.getAsync('sess1'))
+    .then(session => t.equal(session, undefined, 'all sessions cleared'))
+    .then(() => store.client.close(false))
+})
+
 test('existing client', function (t) {
   return Aerospike.connect()
     .then(function (client) {


### PR DESCRIPTION
Update to v3 client:
* Fix Client#get callback due to changed cb method signature.
* No need to "promisify" client for tests since client supports Promises now.
* Drop support for Node.js v0.12 + io.js - min. requirement is Node.js 4 (LTS).